### PR TITLE
Fix for typographical error.

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
 
 <section style="margin-left: unset">
 <h1>Reporting Issues</h1>
-<p>No information source is perfect, and we acknowledge that this wiki may contain inaccuracies or typos. If you end up finding any, we accept Github issue reports <a class="lna" href="https://github.com/tetrio/faq/issues"><b>here</b></a>. You can also send a small message about the issue directed at ZaptorZap#0405 in <a class="lna" href="https://l.tetr.io/discord">the official TETR.IO Discord</a>, and he'll try to correct it as fast as possible.</p>
+<p>No information source is perfect, and we acknowledge that this wiki may contain inaccuracies or typos. If you end up finding any, we accept Github issue reports <a class="lna" href="https://github.com/tetrio/faq/issues"><b>here</b></a>. You can also send a small message about the issue directed at @zaptorzap in <a class="lna" href="https://l.tetr.io/discord">the official TETR.IO Discord</a>, and he'll try to correct it as fast as possible.</p>
 <p class="unemphasis">Further FAQ expansion will be considered at the discretion of the authors.</p>
 </section>
 

--- a/mechanics.html
+++ b/mechanics.html
@@ -253,7 +253,7 @@
     <p>Here's some pointers if you'd like to avoid the automated solutions and instead create your own:</p>
 <ul>
 	<li><a class="lna" href="http://aznguy.com/" title="aznguy.mp4's homepage">aznguy.mp4</a>'s list of <code>/set</code> attributes: as pinned in #tetrio on the official TETR.IO Discord server, it's also available <a class="lna" href="https://tetrio.team2xh.net/?t=faq#commands">on Tenchi's FAQ</a>.</li>
-	<li><a class="lna" href="https://github.com/ZaptorZap/tetriofaq" title="ZaptorZap's github profile">ZaptorZap</a>'s <code>.txt</code> file of complete <code>/set</code> presets: it's always nice to learn by example, so here's a five for one deal! Download it <a class="lna" href="https://cdn.discordapp.com/attachments/763146093655359488/917684858099232798/tetrio_multiplayer_rule_presets.txt">here</a> (if you have suggestions for new presets, feel free to direct message ZaptorZap#0405 about them!)</li>
+	<li><a class="lna" href="https://github.com/ZaptorZap/tetriofaq" title="ZaptorZap's github profile">ZaptorZap</a>'s <code>.txt</code> file of complete <code>/set</code> presets: it's always nice to learn by example, so here's a five for one deal! Download it <a class="lna" href="https://cdn.discordapp.com/attachments/763146093655359488/917684858099232798/tetrio_multiplayer_rule_presets.txt">here</a> (if you have suggestions for new presets, feel free to direct message @zaptorzap on Discord about them!)</li>
 </ul>
 	<p>As well as these resources, here's some more specific advice: note that <code>/set</code> presets <strong>are bound by TETR.IO's 512 character chat limit</strong>. If a <code>/set</code> preset calls for more than this limit, either split it up into two halves or try to truncate defaults settings out.</p>
 </section>


### PR DESCRIPTION
In the Reporting issues section, it instructs the user to talk to ZaptorZap#0405 in the TETR.IO Discord server. Discord has pushed out the new username sysetem, rendering the tag-based username useless. I have appropriately fixed this error by replacing the tag username with ZaptorZap's correct username on Discord.