### PR TITLE
Fix ToC Overlap with Content on Widescreen

### DIFF
--- a/res/style.css
+++ b/res/style.css
@@ -43,7 +43,7 @@
 	left: 0;
 	top: 0;
 	bottom: 0;
-	width: calc(20vw + 1em);
+	width: calc(10vw + 13em);
 	padding-top: 7em;
 	padding-bottom: 1em;
 	overflow-y: auto;


### PR DESCRIPTION
The Table of Contents previously overlapped with the main content when on widescreen. This fix prevents overlapping.

The effect can also be seen when zooming out with ctrl+-.

===

# 3440px width monitor
Before
![image](https://github.com/user-attachments/assets/541e9902-a083-43de-a213-53555eb2c70b)

After
![image](https://github.com/user-attachments/assets/75a0a738-0c2f-4157-b33e-2a0ccbe47757)

# 1920px width monitor
(no noticable difference)

# 1200px width monitor
Before
![image](https://github.com/user-attachments/assets/c259d7d9-ee1e-4daf-9143-3667a4dafd5b)

After
![image](https://github.com/user-attachments/assets/f00e3530-06bb-42f7-a293-b112a4e1323c)