### PR TITLE
Fixed dead 'DAS and ARR gif' link.

### DIFF
--- a/mechanics.html
+++ b/mechanics.html
@@ -153,7 +153,7 @@
     <p><em>also see:</em></p>
 <ul>
 	<li><a class="lna" href="https://www.youtube.com/watch?v=rKQZdRu6_g0" title="How to properly set your TETR.IO Handling!">25Pi25's YouTube video</a> summarizing how to set your handling.</li>
-	<li><a class="lna" href="https://cdn.discordapp.com/attachments/813901028394795078/871859207605985300/DAS_and_ARR.gif?ex=677d9529&is=677c43a9&hm=8535845654e90728eea9d3e77c759ab84bcb1f872f1c167c5f3c936dc7528dfc&">This instinctual <code>.gif</code> file</a> everyone keeps sharing to which I cannot attribute to anyone at this point.</li>
+	<li><a class="lna" href="https://zudo.pics/342h1qfh.gif">This instinctual <code>.gif</code> file</a> everyone keeps sharing to which I cannot attribute to anyone at this point.</li>
 	<li><a class="lna" href="http://tetrio.team2xh.net/?t=faq#handling">Tenchi's FAQ on the difference between TETR.IO and Jstris handling</a>.<ul>
 		<li>A commonly suggested workaround if changing between the two games is really simple, just do some quick addition:</li>
 </ul></li></ul>

--- a/mechanics.html
+++ b/mechanics.html
@@ -153,7 +153,7 @@
     <p><em>also see:</em></p>
 <ul>
 	<li><a class="lna" href="https://www.youtube.com/watch?v=rKQZdRu6_g0" title="How to properly set your TETR.IO Handling!">25Pi25's YouTube video</a> summarizing how to set your handling.</li>
-	<li><a class="lna" href="https://cdn.discordapp.com/attachments/813901028394795078/871859207605985300/DAS_and_ARR.gif">This instinctual <code>.gif</code> file</a> everyone keeps sharing to which I cannot attribute to anyone at this point.</li>
+	<li><a class="lna" href="https://cdn.discordapp.com/attachments/813901028394795078/871859207605985300/DAS_and_ARR.gif?ex=677d9529&is=677c43a9&hm=8535845654e90728eea9d3e77c759ab84bcb1f872f1c167c5f3c936dc7528dfc&">This instinctual <code>.gif</code> file</a> everyone keeps sharing to which I cannot attribute to anyone at this point.</li>
 	<li><a class="lna" href="http://tetrio.team2xh.net/?t=faq#handling">Tenchi's FAQ on the difference between TETR.IO and Jstris handling</a>.<ul>
 		<li>A commonly suggested workaround if changing between the two games is really simple, just do some quick addition:</li>
 </ul></li></ul>


### PR DESCRIPTION
Original link to the .gif was deleted. This links to a newer one.